### PR TITLE
wilson confidence interval calculation with pyspark

### DIFF
--- a/replay/models/association_rules.py
+++ b/replay/models/association_rules.py
@@ -33,9 +33,9 @@ class AssociationRulesItemRec(Recommender):
         """
         :param session_col: name of column to group sessions.
             Items are combined by the ``user_id`` column if ``session_col`` is not defined.
-        :param min_item_count items with fewer sessions will be filtered out
-        :param min_pair_count pairs with fewer sessions will be filtered out
-        :param num_neighbours maximal number of neighbours to save for each item
+        :param min_item_count: items with fewer sessions will be filtered out
+        :param min_pair_count: pairs with fewer sessions will be filtered out
+        :param num_neighbours: maximal number of neighbours to save for each item
         """
         self.session_col = (
             session_col if session_col is not None else "user_idx"
@@ -50,7 +50,6 @@ class AssociationRulesItemRec(Recommender):
         user_features: Optional[DataFrame] = None,
         item_features: Optional[DataFrame] = None,
     ) -> None:
-
         """
         1) Filter log items by ``min_item_count`` threshold
         2) Calculate items support, pairs confidence, lift and confidence_gain defined as
@@ -130,7 +129,8 @@ class AssociationRulesItemRec(Recommender):
                     "similarity_order",
                     sf.row_number().over(
                         Window.partitionBy("antecedent").orderBy(
-                            sf.col("lift").desc(), sf.col("consequent").desc(),
+                            sf.col("lift").desc(),
+                            sf.col("consequent").desc(),
                         )
                     ),
                 )

--- a/tests/models/test_wilson.py
+++ b/tests/models/test_wilson.py
@@ -1,0 +1,74 @@
+# pylint: disable=redefined-outer-name, missing-function-docstring, unused-import
+import pytest
+import numpy as np
+
+from pyspark.sql import functions as sf
+from statsmodels.stats.proportion import proportion_confint
+
+from replay.models import Wilson
+from replay.utils import convert2spark
+from tests.utils import log, spark, sparkDataFrameEqual
+
+
+@pytest.fixture
+def model():
+    model = Wilson()
+    return model
+
+
+def test_works(log, model):
+    log = log.withColumn(
+        "relevance", sf.when(sf.col("relevance") < 3, 0).otherwise(1)
+    )
+    model.fit(log)
+    model.item_popularity.count()
+
+
+def calc_wilson_interval(log):
+    data_frame = (
+        log.groupby("item_id")
+        .agg(
+            sf.sum("relevance").alias("pos"),
+            sf.count("relevance").alias("total"),
+        )
+        .toPandas()
+    )
+    pos = np.array(data_frame["pos"].values)
+    total = np.array(data_frame["total"].values)
+    data_frame["relevance"] = proportion_confint(pos, total, method="wilson")[
+        0
+    ]
+    data_frame = data_frame.drop(["pos", "total"], axis=1)
+    return convert2spark(data_frame)
+
+
+def test_calculation(log, model):
+    log = log.withColumn(
+        "relevance", sf.when(sf.col("relevance") < 3, 0).otherwise(1)
+    )
+    model.fit(log)
+    stat_wilson = calc_wilson_interval(log)
+    spark_wilson = model._convert_back(
+        model.item_popularity,
+        log.schema["user_id"].dataType,
+        log.schema["item_id"].dataType,
+    )
+    sparkDataFrameEqual(spark_wilson, stat_wilson)
+
+
+def test_predict(log, model):
+    log = log.withColumn(
+        "relevance", sf.when(sf.col("relevance") < 3, 0).otherwise(1)
+    )
+    model.fit(log)
+    recs = model.predict(
+        log, k=1, users=["user2", "user1"], items=["item4", "item3"]
+    )
+    recs.show()
+    assert recs.count() == 2
+    assert (
+        recs.select(
+            sf.sum(sf.col("user_id").isin(["user2", "user1"]).astype("int"))
+        ).collect()[0][0]
+        == 2
+    )

--- a/tests/models/test_wilson.py
+++ b/tests/models/test_wilson.py
@@ -64,7 +64,6 @@ def test_predict(log, model):
     recs = model.predict(
         log, k=1, users=["user2", "user1"], items=["item4", "item3"]
     )
-    recs.show()
     assert recs.count() == 2
     assert (
         recs.select(


### PR DESCRIPTION
- lower bound of wilson confidence interval calculation with pyspark instead of statsmodels.stats.proportion.proportion_confint
- tests added for wilson model
- alpha (significance level) added as a hyperparameter