### PR TITLE
bug fix in predict wrap

### DIFF
--- a/replay/models/base_rec.py
+++ b/replay/models/base_rec.py
@@ -397,6 +397,61 @@ class BaseRecommender(ABC):
         :return:
         """
 
+    @staticmethod
+    def _filter_seen(
+        recs: DataFrame, log: DataFrame, k: int, users: DataFrame
+    ):
+        """
+        Filter seen items from prediction:
+            - counts maximal number of items seen by users is prediction (max_seen)
+            - crop recommendations to first k + max_seen items for each user
+            - join cropped recommendations with history length for each user with broadcast join
+            - leave k + number of items seen by user items for each user
+            - anti-join interactions log to liter seen items
+        For each user returns from k to k + number of seen by user recommendations.
+        """
+
+        users_log = log.join(users, on="user_idx").cache()
+        num_of_seen = (
+            users_log.groupBy("user_idx").agg(
+                sf.count("item_idx").alias("seen_count")
+            )
+        ).cache()
+
+        max_seen = 0
+        if num_of_seen.count() > 0:
+            max_seen = num_of_seen.select(sf.max("seen_count")).collect()[0][0]
+
+        recs = recs.withColumn(
+            "temp_rank",
+            sf.row_number().over(
+                Window.partitionBy("user_idx").orderBy(
+                    sf.col("relevance").desc()
+                )
+            ),
+        ).filter(sf.col("temp_rank") <= sf.lit(max_seen + k))
+
+        recs = (
+            recs.join(sf.broadcast(num_of_seen), on="user_idx", how="left")
+            .fillna(0)
+            .filter(sf.col("temp_rank") <= sf.col("seen_count") + sf.lit(k))
+            .drop("temp_rank", "seen_count")
+        )
+
+        recs = recs.join(
+            users_log.withColumnRenamed("item_idx", "item")
+            .withColumnRenamed("user_idx", "user")
+            .select("user", "item"),
+            on=(sf.col("user_idx") == sf.col("user"))
+            & (sf.col("item_idx") == sf.col("item")),
+            how="anti",
+        ).drop("user", "item")
+
+        users_log.unpersist()
+        num_of_seen.unpersist()
+
+        return recs
+
     # pylint: disable=too-many-arguments
     def _predict_wrap(
         self,
@@ -464,46 +519,12 @@ class BaseRecommender(ABC):
             filter_seen_items,
         )
         if filter_seen_items and log:
-            num_of_seen = (
-                log.groupBy("user_idx")
-                .agg(sf.count("item_idx").alias("seen_count"))
-                .cache()
-            )
+            recs = self._filter_seen(recs=recs, log=log, users=users, k=k)
 
-            max_seen = num_of_seen.select(sf.max("seen_count")).collect()[0][0]
-
-            recs = recs.withColumn(
-                "temp_rank",
-                sf.row_number().over(
-                    Window.partitionBy("user_idx").orderBy(
-                        sf.col("relevance").desc()
-                    )
-                ),
-            ).filter(sf.col("temp_rank") <= sf.lit(max_seen + k))
-
-            recs = (
-                recs.join(sf.broadcast(num_of_seen), on="user_idx", how="left")
-                .fillna(0)
-                .filter(
-                    sf.col("temp_rank") <= sf.col("seen_count") + sf.lit(k)
-                )
-                .drop("temp_rank", "seen_count")
-            )
-            num_of_seen.unpersist()
-
-            recs = recs.join(
-                log.withColumnRenamed("item_idx", "item")
-                .withColumnRenamed("user_idx", "user")
-                .select("user", "item"),
-                on=(sf.col("user_idx") == sf.col("user"))
-                & (sf.col("item_idx") == sf.col("item")),
-                how="anti",
-            ).drop("user", "item")
-
-        recs = self._convert_back(recs, users_type, items_type).select(
+        recs = get_top_k_recs(recs, k=k, id_type="idx")
+        return self._convert_back(recs, users_type, items_type).select(
             "user_id", "item_id", "relevance"
         )
-        return get_top_k_recs(recs, k=k)
 
     def _convert_index(
         self, data_frame: Optional[DataFrame]
@@ -590,7 +611,8 @@ class BaseRecommender(ABC):
 
     @staticmethod
     def _get_ids(
-        log: Union[Iterable, AnyDataFrame], column: str,
+        log: Union[Iterable, AnyDataFrame],
+        column: str,
     ) -> DataFrame:
         """
         Get unique values from ``array`` and put them into dataframe with column ``column``.
@@ -858,7 +880,10 @@ class BaseRecommender(ABC):
 
         if self.can_predict_item_to_item:
             return self._get_nearest_items_wrap(
-                items=items, k=k, metric=metric, candidates=candidates,
+                items=items,
+                k=k,
+                metric=metric,
+                candidates=candidates,
             )
 
         raise ValueError(
@@ -886,7 +911,9 @@ class BaseRecommender(ABC):
         ]
 
         nearest_items_to_filter = self._get_nearest_items(
-            items=items, metric=metric, candidates=candidates,
+            items=items,
+            metric=metric,
+            candidates=candidates,
         )
 
         rel_col_name = metric if metric is not None else "similarity"
@@ -1426,7 +1453,11 @@ class NeighbourRec(Recommender, ABC):
                 how="inner",
                 on=sf.col("item_idx") == sf.col("item_id_one"),
             )
-            .join(filter_df, how="inner", on=condition,)
+            .join(
+                filter_df,
+                how="inner",
+                on=condition,
+            )
             .groupby("user_idx", "item_id_two")
             .agg(sf.sum("similarity").alias("relevance"))
             .withColumnRenamed("item_id_two", "item_idx")
@@ -1498,7 +1529,10 @@ class NeighbourRec(Recommender, ABC):
             )
 
         return self._get_nearest_items_wrap(
-            items=items, k=k, metric=None, candidates=candidates,
+            items=items,
+            k=k,
+            metric=None,
+            candidates=candidates,
         )
 
     def _get_nearest_items(

--- a/replay/models/pop_rec.py
+++ b/replay/models/pop_rec.py
@@ -116,38 +116,31 @@ class PopRec(Recommender):
         filter_seen_items: bool = True,
     ) -> DataFrame:
         selected_item_popularity = self.item_popularity.join(
-            items, on="item_idx", how="inner",
+            items,
+            on="item_idx",
+            how="inner",
         ).withColumn(
             "rank",
             sf.row_number().over(Window.orderBy(sf.col("relevance").desc())),
         )
 
-        if not filter_seen_items:
-            return users.crossJoin(
-                selected_item_popularity.filter(sf.col("rank") <= k)
-            ).drop("rank")
+        max_hist_len = 0
+        if filter_seen_items:
+            max_hist_len = (
+                (
+                    log.join(users, on="user_idx")
+                    .groupBy("user_idx")
+                    .agg(sf.countDistinct("item_idx").alias("items_count"))
+                )
+                .select(sf.max("items_count"))
+                .collect()[0][0]
+            )
+            if max_hist_len is None:
+                max_hist_len = 0
 
-        log_by_user = (
-            log.join(users, on="user_idx")
-            .groupBy("user_idx")
-            .agg(sf.countDistinct("item_idx").alias("items_count"))
-        )
-        max_history_len = log_by_user.select(sf.max("items_count")).collect()[
-            0
-        ][0]
-        cropped_item_popularity = selected_item_popularity.filter(
-            sf.col("rank") <= max_history_len + k
-        )
-
-        log_by_user_with_new_users = log_by_user.join(
-            users, on="user_idx", how="right"
-        ).fillna(0)
-        recs = log_by_user_with_new_users.join(
-            cropped_item_popularity,
-            on=sf.col("rank") <= sf.col("items_count") + sf.lit(k),
-        ).drop("rank", "items_count")
-
-        return recs
+        return users.crossJoin(
+            selected_item_popularity.filter(sf.col("rank") <= k + max_hist_len)
+        ).drop("rank")
 
     def _predict_pairs(
         self,

--- a/tests/models/test_all_models.py
+++ b/tests/models/test_all_models.py
@@ -205,3 +205,21 @@ def test_nearest_items_raises(log):
             model.get_nearest_items(
                 items=["item1", "item2"], k=2, metric="cosine_similarity"
             )
+
+
+def test_filter_seen(log):
+    model = PopRec()
+    # filter seen works with empty log to filter (cold_user)
+    model.fit(log.filter(sf.col("user_id") != "user1"))
+    pred = model.predict(log=log, users=["user5"], k=5)
+    assert pred.count() == 4
+
+    # filter seen works with log not presented during training (for user1)
+    pred = model.predict(log=log, users=["user1"], k=5)
+    assert pred.count() == 1
+
+    # filter seen turns off
+    pred = model.predict(
+        log=log, users=["user1"], k=5, filter_seen_items=False
+    )
+    assert pred.count() == 4


### PR DESCRIPTION
there was a bug in seen filtering appearing if there was no history in log for all users in predict (max_seen turns into None). 
The code:
- fixes the bug and moves filter seen code to a separate function
- removes duplicated code of seen filtering from poprec