### PR TITLE
Two stages fallback bugfix

### DIFF
--- a/replay/scenarios/two_stages/two_stages_scenario.py
+++ b/replay/scenarios/two_stages/two_stages_scenario.py
@@ -448,7 +448,11 @@ class TwoStagesScenario(HybridRecommender):
                 for df in [log, users, user_features]
             ]
 
-        log_to_filter_cached = log_to_filter.join(users, on="user_idx").cache()
+        log_to_filter_cached = ugly_join(
+            left=log_to_filter,
+            right=users,
+            on_col_name="user_idx",
+        ).cache()
         max_positives_to_filter = 0
 
         if log_to_filter_cached.count() > 0:

--- a/replay/scenarios/two_stages/two_stages_scenario.py
+++ b/replay/scenarios/two_stages/two_stages_scenario.py
@@ -535,8 +535,9 @@ class TwoStagesScenario(HybridRecommender):
         candidates = self._predict_with_first_level_model(**passed_arguments)
 
         if self.fallback_model is not None:
+            passed_arguments.pop("model")
             fallback_candidates = self._predict_with_first_level_model(
-                **passed_arguments
+                model=self.fallback_model, **passed_arguments
             )
 
             candidates = fallback(

--- a/replay/scenarios/two_stages/two_stages_scenario.py
+++ b/replay/scenarios/two_stages/two_stages_scenario.py
@@ -448,16 +448,16 @@ class TwoStagesScenario(HybridRecommender):
                 for df in [log, users, user_features]
             ]
 
-        max_positives_to_filter = min(
-            [
-                log_to_filter.groupBy("user_idx")
+        log_to_filter_cached = log_to_filter.join(users, on="user_idx").cache()
+        max_positives_to_filter = 0
+
+        if log_to_filter_cached.count() > 0:
+            max_positives_to_filter = (
+                log_to_filter_cached.groupBy("user_idx")
                 .agg(sf.count("item_idx").alias("num_positives"))
                 .select(sf.max("num_positives"))
-                .collect()[0][0],
-                log.select("item_idx").distinct().count() - k,
-                items.select("item_idx").distinct().count() - k,
-            ]
-        )
+                .collect()[0][0]
+            )
 
         pred = model._predict(
             log,
@@ -470,10 +470,12 @@ class TwoStagesScenario(HybridRecommender):
         )
 
         pred = pred.join(
-            log_to_filter.select("user_idx", "item_idx"),
+            log_to_filter_cached.select("user_idx", "item_idx"),
             on=["user_idx", "item_idx"],
             how="anti",
         ).drop("user", "item")
+
+        log_to_filter_cached.unpersist()
 
         return get_top_k_recs(pred, k, id_type="idx")
 


### PR DESCRIPTION
- there was a bug in first-level predict as main model predict was called twice instead of main model predict + fallback model predict. fixed
- calculation of the number of items to predict by the first level model (to filter seen and get > k recommendations) changed to take into account only the users to predict for