### PR TITLE
test predict for new and cold users

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ numba = ">=0.50"
 llvmlite = ">=0.32.1"
 seaborn = "*"
 pyarrow = "*"
-implicit = "*"
+implicit = "<0.5"
 
 [tool.poetry.dev-dependencies]
 # dev only

--- a/replay/models/cluster.py
+++ b/replay/models/cluster.py
@@ -92,7 +92,9 @@ class ClusterRec(UserRecommender):
         filter_seen_items: bool = True,
     ) -> DataFrame:
 
-        user_features_vector = self._transform_features(user_features)
+        user_features_vector = self._transform_features(
+            user_features.join(users, on="user_idx")
+        )
         user_clusters = (
             self.model.transform(user_features_vector)
             .select("user_idx", "prediction")

--- a/replay/models/neuromf.py
+++ b/replay/models/neuromf.py
@@ -206,7 +206,7 @@ class NMF(nn.Module):
             mlp_vector = torch.zeros(batch_size, 0).to(user.device)
 
         merged_vector = torch.cat([gmf_vector, mlp_vector], dim=1)
-        merged_vector = self.last_layer(merged_vector).squeeze()
+        merged_vector = self.last_layer(merged_vector).squeeze(dim=1)
         merged_vector = torch.sigmoid(merged_vector)
 
         return merged_vector
@@ -396,7 +396,10 @@ class NeuroMF(TorchRecommender):
             user_batch = LongTensor([user_idx] * len(items_np))
             item_batch = LongTensor(items_np)
             user_recs = torch.reshape(
-                model(user_batch, item_batch).detach(), [-1,],
+                model(user_batch, item_batch).detach(),
+                [
+                    -1,
+                ],
             )
             if cnt is not None:
                 best_item_idx = (

--- a/tests/models/test_all_models.py
+++ b/tests/models/test_all_models.py
@@ -234,14 +234,10 @@ def test_filter_seen(log):
     assert pred.count() == 4
 
 
-def get_kwargs(model, user_features):
-    if isinstance(model, (HybridRecommender, UserRecommender)):
-        return {"user_features": user_features}
-    return {}
-
-
 def fit_predict_selected(model, train_log, inf_log, user_features, users):
-    kwargs = get_kwargs(model, user_features)
+    kwargs = {}
+    if isinstance(model, (HybridRecommender, UserRecommender)):
+        kwargs = {"user_features": user_features}
     model.fit(train_log, **kwargs)
     return model.predict(log=inf_log, users=users, k=1, **kwargs)
 

--- a/tests/models/test_all_models.py
+++ b/tests/models/test_all_models.py
@@ -10,16 +10,25 @@ from replay.constants import LOG_SCHEMA
 from replay.models import (
     ALSWrap,
     ADMMSLIM,
+    ClusterRec,
     KNN,
     LightFMWrap,
     NeuroMF,
     PopRec,
+    RandomRec,
     SLIM,
     MultVAE,
     Word2VecRec,
 )
+from replay.models.base_rec import HybridRecommender, UserRecommender
 
-from tests.utils import spark, log, sparkDataFrameEqual
+from tests.utils import (
+    spark,
+    log,
+    long_log_with_features,
+    user_features,
+    sparkDataFrameEqual,
+)
 
 SEED = 123
 
@@ -223,3 +232,115 @@ def test_filter_seen(log):
         log=log, users=["user1"], k=5, filter_seen_items=False
     )
     assert pred.count() == 4
+
+
+def get_kwargs(model, user_features):
+    if isinstance(model, (HybridRecommender, UserRecommender)):
+        return {"user_features": user_features}
+    return {}
+
+
+def fit_predict_selected(model, train_log, inf_log, user_features, users):
+    kwargs = get_kwargs(model, user_features)
+    model.fit(train_log, **kwargs)
+    return model.predict(log=inf_log, users=users, k=1, **kwargs)
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        ADMMSLIM(seed=SEED),
+        ClusterRec(num_clusters=2),
+        KNN(),
+        LightFMWrap(random_state=SEED, no_components=4),
+        MultVAE(),
+        SLIM(seed=SEED),
+        PopRec(),
+        RandomRec(seed=SEED),
+        Word2VecRec(seed=SEED, min_count=0),
+    ],
+    ids=[
+        "admm_slim",
+        "cluster",
+        "knn",
+        "lightfm",
+        "multvae",
+        "slim",
+        "pop_rec",
+        "random_rec",
+        "word2vec",
+    ],
+)
+def test_predict_new_users(model, long_log_with_features, user_features):
+    pred = fit_predict_selected(
+        model,
+        train_log=long_log_with_features.filter(sf.col("user_id") != "u1"),
+        inf_log=long_log_with_features,
+        user_features=user_features.drop("gender"),
+        users=["u1"],
+    )
+    assert pred.count() == 1
+    assert pred.collect()[0][0] == "u1"
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        ClusterRec(num_clusters=2),
+        LightFMWrap(random_state=SEED, no_components=4),
+        PopRec(),
+        RandomRec(seed=SEED),
+    ],
+    ids=[
+        "cluster",
+        "lightfm",
+        "pop_rec",
+        "random_rec",
+    ],
+)
+def test_predict_cold_users(model, long_log_with_features, user_features):
+    pred = fit_predict_selected(
+        model,
+        train_log=long_log_with_features.filter(sf.col("user_id") != "u1"),
+        inf_log=long_log_with_features.filter(sf.col("user_id") != "u1"),
+        user_features=user_features.drop("gender"),
+        users=["u1"],
+    )
+    assert pred.count() == 1
+    assert pred.collect()[0][0] == "u1"
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        ALSWrap(rank=2, seed=SEED),
+        KNN(),
+        LightFMWrap(),
+        MultVAE(),
+        NeuroMF(),
+        SLIM(seed=SEED),
+        Word2VecRec(seed=SEED, min_count=0),
+    ],
+    ids=[
+        "als",
+        "knn",
+        "lightfm_no_feat",
+        "multvae",
+        "neuromf",
+        "slim",
+        "word2vec",
+    ],
+)
+def test_predict_cold_and_new_filter_out(model, long_log_with_features):
+    pred = fit_predict_selected(
+        model,
+        train_log=long_log_with_features.filter(sf.col("user_id") != "u1"),
+        inf_log=long_log_with_features,
+        user_features=None,
+        users=["u1", "cold_user"],
+    )
+    # assert new/cold users are filtered out in `predict`
+    if isinstance(model, LightFMWrap) or not model.can_predict_cold_users:
+        assert pred.count() == 0
+    else:
+        assert 1 <= pred.count() <= 2

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -104,7 +104,11 @@ def short_log_with_features(spark):
 @pytest.fixture
 def user_features(spark):
     return spark.createDataFrame(
-        [("u1", 20.0, -3.0, "M"), ("u2", 30.0, 4.0, "F")]
+        [
+            ("u1", 20.0, -3.0, "M"),
+            ("u2", 30.0, 4.0, "F"),
+            ("u3", 75.0, -1.0, "M"),
+        ]
     ).toDF("user_id", "age", "mood", "gender")
 
 


### PR DESCRIPTION
tests added to check:
- models, which are able to recommend for cold/new users, really do it
- models, which are not able to recommend for cold/new users filter those users out and do not fail

bugs found and fixed:
- cluster model did not filter users in `_predict`
- in neuromf net.forward could return a number instead of tensor for batch of one element as `.squeeze` was used without `dim` parameter