### PR TITLE
Predict items

### DIFF
--- a/replay/models/base_rec.py
+++ b/replay/models/base_rec.py
@@ -455,7 +455,7 @@ class BaseRecommender(ABC):
         users = self._get_ids(user_data, "user_idx")
         users = self._filter_ids(users, "user_idx")
 
-        item_data = items or self.fit_items or log or item_features
+        item_data = items or self.fit_items
         items = self._get_ids(item_data, "item_idx")
         items = self._filter_ids(items, "item_idx")
 

--- a/replay/models/base_rec.py
+++ b/replay/models/base_rec.py
@@ -455,7 +455,7 @@ class BaseRecommender(ABC):
         users = self._get_ids(user_data, "user_idx")
         users = self._filter_ids(users, "user_idx")
 
-        item_data = items or log or item_features or self.fit_items
+        item_data = items or self.fit_items or log or item_features
         items = self._get_ids(item_data, "item_idx")
         items = self._filter_ids(items, "item_idx")
 

--- a/replay/scenarios/two_stages/two_stages_scenario.py
+++ b/replay/scenarios/two_stages/two_stages_scenario.py
@@ -65,7 +65,10 @@ def get_first_level_model_features(
         pairs, user_factors, how="left", on="user_idx"
     )
     pairs_with_features = join_or_return(
-        pairs_with_features, item_factors, how="left", on="item_idx",
+        pairs_with_features,
+        item_factors,
+        how="left",
+        on="item_idx",
     )
 
     factors_to_explode = []
@@ -331,7 +334,10 @@ class TwoStagesScenario(HybridRecommender):
             how="left",
         )
         full_second_level_train = join_or_return(
-            full_second_level_train, item_features, on="item_idx", how="left",
+            full_second_level_train,
+            item_features,
+            on="item_idx",
+            how="left",
         )
 
         if self.use_generated_features:
@@ -366,14 +372,6 @@ class TwoStagesScenario(HybridRecommender):
             "second_level_train info: %s", get_log_info(second_level_train)
         )
         return first_level_train, second_level_train
-
-    def _fit_wrap(
-        self,
-        log: AnyDataFrame,
-        user_features: Optional[AnyDataFrame] = None,
-        item_features: Optional[AnyDataFrame] = None,
-    ) -> None:
-        self._fit(log, user_features, item_features)
 
     @staticmethod
     def _filter_or_return(dataframe, condition):
@@ -413,7 +411,9 @@ class TwoStagesScenario(HybridRecommender):
             ]
 
         log_to_filter_cached = ugly_join(
-            left=log_to_filter, right=users, on_col_name="user_idx",
+            left=log_to_filter,
+            right=users,
+            on_col_name="user_idx",
         ).cache()
         max_positives_to_filter = 0
 


### PR DESCRIPTION
- if `items` were not passed to predict, items from `log` were used, but we actually want to get prediction from `fit_items`,  
- now items are `items` or `fit_items`

-fit wrap deleted for TwoStagesScenario as fit_items are required for predict now and were not set before.
