### PR TITLE
pylint: self added as an argument in base classes

### DIFF
--- a/replay/history_based_fp.py
+++ b/replay/history_based_fp.py
@@ -22,15 +22,14 @@ from replay.utils import join_or_return, ugly_join, unpersist_if_exists
 class EmptyFeatureProcessor:
     """Do not perform any transformations on the dataframe"""
 
-    @staticmethod
-    def fit(log: DataFrame, features: DataFrame) -> None:
+    def fit(self, log: DataFrame, features: DataFrame) -> None:
         """
         :param log: input DataFrame ``[user_idx, item_idx, timestamp, relevance]``
         :param features: DataFrame with ``user_idx/item_idx`` and feature columns
         """
 
-    @staticmethod
-    def transform(log: DataFrame) -> DataFrame:
+    # pylint: disable=no-self-use
+    def transform(self, log: DataFrame) -> DataFrame:
         """
         Return log without any transformations
         :param log: spark DataFrame

--- a/replay/metrics/base_metric.py
+++ b/replay/metrics/base_metric.py
@@ -239,10 +239,10 @@ class RecOnlyMetric(Metric):
     def __init__(self, log: AnyDataFrame, *args, **kwargs):
         pass
 
-    @staticmethod
+    # pylint: disable=no-self-use
     @abstractmethod
     def _get_enriched_recommendations(
-        recommendations: AnyDataFrame, ground_truth: AnyDataFrame
+        self, recommendations: AnyDataFrame, ground_truth: AnyDataFrame
     ) -> DataFrame:
         pass
 

--- a/replay/metrics/coverage.py
+++ b/replay/metrics/coverage.py
@@ -38,27 +38,34 @@ class Coverage(RecOnlyMetric):
         # not averaged by users
         pass
 
-    @staticmethod
+    # pylint: disable=no-self-use
     def _get_enriched_recommendations(
-        recommendations: AnyDataFrame, ground_truth: AnyDataFrame
+        self, recommendations: AnyDataFrame, ground_truth: AnyDataFrame
     ) -> DataFrame:
         return convert2spark(recommendations)
 
     def _conf_interval(
-        self, recs: AnyDataFrame, k_list: IntOrList, alpha: float = 0.95,
+        self,
+        recs: AnyDataFrame,
+        k_list: IntOrList,
+        alpha: float = 0.95,
     ) -> Union[Dict[int, float], float]:
         if isinstance(k_list, int):
             return 0.0
         return {i: 0.0 for i in k_list}
 
     def _median(
-        self, recs: AnyDataFrame, k_list: IntOrList,
+        self,
+        recs: AnyDataFrame,
+        k_list: IntOrList,
     ) -> Union[Dict[int, NumType], NumType]:
         return self._mean(recs, k_list)
 
     @process_k
     def _mean(
-        self, recs: DataFrame, k_list: list,
+        self,
+        recs: DataFrame,
+        k_list: list,
     ) -> Union[Dict[int, NumType], NumType]:
         unknown_item_count = (
             recs.select("item_idx")  # type: ignore

--- a/replay/models/word2vec.py
+++ b/replay/models/word2vec.py
@@ -80,7 +80,7 @@ class Word2VecRec(Recommender, ItemVectorModel):
             .select(
                 "item_idx",
                 (
-                    sf.log(self.users_count / sf.col("count"))
+                    sf.log(sf.lit(self.users_count) / sf.col("count"))
                     if self.use_idf
                     else sf.lit(1.0)
                 ).alias("idf"),
@@ -134,7 +134,9 @@ class Word2VecRec(Recommender, ItemVectorModel):
         return {"idf": self.idf, "vectors": self.vectors}
 
     def _get_user_vectors(
-        self, users: DataFrame, log: DataFrame,
+        self,
+        users: DataFrame,
+        log: DataFrame,
     ) -> DataFrame:
         """
         :param users: user ids, dataframe ``[user_idx]``
@@ -161,7 +163,9 @@ class Word2VecRec(Recommender, ItemVectorModel):
         )
 
     def _predict_pairs_inner(
-        self, pairs: DataFrame, log: DataFrame,
+        self,
+        pairs: DataFrame,
+        log: DataFrame,
     ) -> DataFrame:
         if log is None:
             raise ValueError(


### PR DESCRIPTION
New pylint does not like cases where a method in a base class is defined as a static method (does not have `self` as a first argument) and the same method in child class is not static (has `self` as a first argument)

I added `self` to base classes' methods signature in metrics and feature processor. This triggers pylint no-selt-use, so I disabled it.

